### PR TITLE
[PLAT-6085] Add SHA option

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ on:
 
 jobs:
   release-on-push:
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -245,6 +245,35 @@ jobs:
           max_commits: 100
 ```
 
+### How can I select a commit SHA different from `GITHUB_SHA`?
+
+By default, the release is created on the commit that triggered the workflow, as identified by the `GITHUB_SHA` environment variable. Sometimes, that's not the desired behaviour; for example, the `workflow_run` event sets `GITHUB_SHA` to the last commit on the default branch, but we might want to tag the commit that was the most recent one when the workflow started.
+
+A different SHA can be selected using the `sha` option. If it is unset, `GITHUB_SHA` is used.
+
+Example usage for a release triggered by a (potentially long running) workflow run:
+
+```yaml
+on:
+  workflow_run:
+    workflows:
+      - Slow CI test workflow
+    types:
+      - completed
+    branches:
+      - master
+
+jobs:
+  release-on-push:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: rymndhng/release-on-push-action@master
+        with:
+          sha: ${{ github.event.workflow_run.head_sha }}
+```
+
 ## Development
 
 Uses [babashka](https://github.com/borkdude/babashka)

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,9 @@ inputs:
     description: "When set to 'true', will compute the next tag, but will not create a release."
     required: false
     default: "false"
+  sha:
+    description: 'The commit SHA to create the release on if different from GITHUB_SHA'
+    required: false
 outputs:
   tag_name:
     description: 'Tag of released version'

--- a/src/release_on_push_action/core.clj
+++ b/src/release_on_push_action/core.clj
@@ -33,7 +33,7 @@
   [args]
   {:token               (getenv-or-throw "GITHUB_TOKEN")
    :repo                (getenv-or-throw "GITHUB_REPOSITORY")
-   :sha                 (getenv-or-throw "GITHUB_SHA")
+   :sha                 (or (System/getenv "INPUT_SHA") (getenv-or-throw "GITHUB_SHA"))
    :github/api-url      (getenv-or-throw "GITHUB_API_URL")
    :github/output       (System/getenv "GITHUB_OUTPUT")
    :input/max-commits   (Integer/parseInt (getenv-or-throw "INPUT_MAX_COMMITS"))


### PR DESCRIPTION
This adds an option to overwrite the commit SHA on which the release is created; by default, that's `GITHUB_SHA`, but for some events such as `workflow_run`, `GITHUB_SHA` might not be what we want.

PLAT-6085